### PR TITLE
(opt-in feature) Make Existing empty Constructors (more) Visible

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -55,6 +55,8 @@
     <Compile Include="ClassAbstractWithEmptyConstructor.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ClassAbstractWithProtectedConstructor.cs" />
+    <Compile Include="ClassAbstractWithPrivateConstructor.cs" />
     <Compile Include="ClassInheritAbstractWithEmptyConstructor.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -101,6 +103,7 @@
     <Compile Include="ClassWithNullableParam.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ClassWithProtectedConstructor.cs" />
     <Compile Include="ClassWithPrivateConstructor.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/AssemblyToProcess/ClassAbstractWithPrivateConstructor.cs
+++ b/AssemblyToProcess/ClassAbstractWithPrivateConstructor.cs
@@ -1,0 +1,6 @@
+﻿public abstract class ClassAbstractWithPrivateConstructor
+{
+    protected ClassAbstractWithPrivateConstructor(int foo) { }
+
+    private ClassAbstractWithPrivateConstructor() { }
+}

--- a/AssemblyToProcess/ClassAbstractWithProtectedConstructor.cs
+++ b/AssemblyToProcess/ClassAbstractWithProtectedConstructor.cs
@@ -1,0 +1,6 @@
+﻿public abstract class ClassAbstractWithProtectedConstructor
+{
+    protected ClassAbstractWithProtectedConstructor(int foo) { }
+
+    protected ClassAbstractWithProtectedConstructor() { }
+}

--- a/AssemblyToProcess/ClassWithProtectedConstructor.cs
+++ b/AssemblyToProcess/ClassWithProtectedConstructor.cs
@@ -1,0 +1,7 @@
+public class ClassWithProtectedConstructor
+{
+// ReSharper disable once UnusedParameter.Local
+    public ClassWithProtectedConstructor(int x) { }
+// ReSharper disable once UnusedMember.Local
+    protected ClassWithProtectedConstructor() { }
+}

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 [assembly: AssemblyTitle("EmptyConstructor")]
 [assembly: AssemblyProduct("EmptyConstructor")]
-[assembly: AssemblyVersion("1.2.1")]
-[assembly: AssemblyFileVersion("1.2.1")]
+[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyFileVersion("1.3.0")]

--- a/Fody/ConfigReader.cs
+++ b/Fody/ConfigReader.cs
@@ -18,6 +18,7 @@ public partial class ModuleWeaver
         }
 
         ReadVisibility();
+        ReadMakeExistingEmptyConstructorsVisible();
         ReadExcludes();
         ReadIncludes();
 
@@ -26,7 +27,6 @@ public partial class ModuleWeaver
             throw new WeavingException("Either configure IncludeNamespaces OR ExcludeNamespaces, not both.");
         }
     }
-
 
     void ReadVisibility()
     {
@@ -47,6 +47,27 @@ public partial class ModuleWeaver
             throw new WeavingException(message);
         }
     }
+
+    void ReadMakeExistingEmptyConstructorsVisible()
+    {
+        var attribute = Config.Attribute("MakeExistingEmptyConstructorsVisible");
+        if (attribute != null)
+        {
+            if (string.Compare(attribute.Value,"true", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                MakeExistingEmptyConstructorsVisible = true;
+                return;
+            }
+            if (string.Compare(attribute.Value, "false", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                MakeExistingEmptyConstructorsVisible = false;
+                return;
+            }
+            var message = $"Could not convert '{attribute.Value}' to a boolean. Only 'true' or 'false' are allowed.";
+            throw new WeavingException(message);
+        }
+    }
+
     void ReadExcludes()
     {
         var excludeNamespacesAttribute = Config.Attribute("ExcludeNamespaces");

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -41,20 +41,16 @@
     <None Include="packages.config" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -94,11 +90,11 @@
     <Copy SourceFiles="$(OutputPath)EmptyConstructor.Fody.pdb" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(SolutionDir)NuGetBuild" MetadataAssembly="$(OutputPath)EmptyConstructor.Fody.dll" />
   </Target>
+  <Import Project="..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets" Condition="Exists('..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets'))" />
+    <Error Condition="!Exists('..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets'))" />
   </Target>
-  <Import Project="..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets" Condition="Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" />
 </Project>

--- a/Fody/packages.config
+++ b/Fody/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FodyCecil" version="2.0.0" targetFramework="net40" developmentDependency="true" />
-  <package id="PepitaPackage" version="1.21.4" targetFramework="net40" developmentDependency="true" />
+  <package id="FodyCecil" version="2.1.2" targetFramework="net40" developmentDependency="true" />
+  <package id="PepitaPackage" version="1.21.6" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,17 @@ Defaults to `public`.
 For example
 
     <EmptyConstructor Visibility='family'/>
+	
+### Making Existing Empty Constructors Visible
 
+Optionally the visibility of already existing constructors can be increased.
+If this feature is enabled, the visibility of empty-constructors of non-abstract types will be increased to the same visibility as defined by the `Visibility` configuration (see above).
+
+For example
+
+    <EmptyConstructor MakeExistingEmptyConstructorsVisible='True'/>
+	
+Will ensure all constructors on non-abstract types will be `public`.
 
 ### ExcludeNamespaces
 

--- a/Tests/ConfigReaderTests.cs
+++ b/Tests/ConfigReaderTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using Mono.Cecil;
 using NUnit.Framework;
 
@@ -50,6 +49,33 @@ Foo.Bar
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ReadConfig();
         Assert.AreEqual(MethodAttributes.Public, moduleWeaver.Visibility);
+    }
+
+    [Test]
+    public void MakeExistingEmptyConstructorsVisible_Default()
+    {
+        var xElement = XElement.Parse("<EmptyConstructor/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ReadConfig();
+        Assert.IsFalse(moduleWeaver.MakeExistingEmptyConstructorsVisible);
+    }
+
+    [Test]
+    public void MakeExistingEmptyConstructorsVisible_False()
+    {
+        var xElement = XElement.Parse("<EmptyConstructor MakeExistingEmptyConstructorsVisible='False'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ReadConfig();
+        Assert.IsFalse(moduleWeaver.MakeExistingEmptyConstructorsVisible);
+    }
+
+    [Test]
+    public void MakeExistingEmptyConstructorsVisible_True()
+    {
+        var xElement = XElement.Parse("<EmptyConstructor MakeExistingEmptyConstructorsVisible='True'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ReadConfig();
+        Assert.IsTrue(moduleWeaver.MakeExistingEmptyConstructorsVisible);
     }
 
     [Test]

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Mono.Cecil;
 using NUnit.Framework;
@@ -75,7 +76,7 @@ public class IntegrationTests
     }
 
 
-[Test]
+    [Test]
     [Explicit]
     public void ClassWithInitializedFields()
     {
@@ -129,7 +130,43 @@ public class IntegrationTests
         Activator.CreateInstance(type);
     }
 
+    [Test]
+    public void ClassWithPrivateEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassWithPrivateConstructor", true);
+        Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(type));
+    }
 
+    [Test]
+    public void ClassWithProtectedEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassWithProtectedConstructor", true);
+        Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(type));
+    }
+
+    [Test]
+    public void ClassAbstractWithPrivateEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassAbstractWithPrivateConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsFalse(constructorInfo.IsPublic);
+        Assert.IsFalse(constructorInfo.IsFamily);
+    }
+
+    [Test]
+    public void ClassAbstractWithProtectedEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassAbstractWithProtectedConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsTrue(constructorInfo.IsFamily);
+        Assert.IsFalse(constructorInfo.IsPublic);
+    }
 
 #if(DEBUG)
     [Test]

--- a/Tests/MakeExistingEmptyConstructorsFamilyIntegrationTests.cs
+++ b/Tests/MakeExistingEmptyConstructorsFamilyIntegrationTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+using NUnit.Framework;
+using MethodAttributes = Mono.Cecil.MethodAttributes;
+
+[TestFixture]
+public class MakeExistingEmptyConstructorsFamilyIntegrationTests
+{
+    Assembly assembly;
+    List<string> warnings = new List<string>();
+    string beforeAssemblyPath;
+    string afterAssemblyPath;
+
+    public MakeExistingEmptyConstructorsFamilyIntegrationTests()
+    {
+        beforeAssemblyPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, @"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll"));
+#if (!DEBUG)
+        beforeAssemblyPath = beforeAssemblyPath.Replace("Debug", "Release");
+#endif
+
+        afterAssemblyPath = beforeAssemblyPath.Replace(".dll", "5.dll");
+        File.Copy(beforeAssemblyPath, afterAssemblyPath, true);
+
+        var assemblyResolver = new MockAssemblyResolver
+        {
+            Directory = Path.GetDirectoryName(beforeAssemblyPath)
+        };
+        using (var moduleDefinition = ModuleDefinition.ReadModule(beforeAssemblyPath, new ReaderParameters
+        {
+            AssemblyResolver = assemblyResolver
+        }))
+        {
+            var weavingTask = new ModuleWeaver
+            {
+                ModuleDefinition = moduleDefinition,
+                AssemblyResolver = assemblyResolver,
+                LogWarning = s => warnings.Add(s),
+                Visibility = MethodAttributes.Family,
+                MakeExistingEmptyConstructorsVisible = true
+            };
+
+            weavingTask.Execute();
+            moduleDefinition.Write(afterAssemblyPath);
+        }
+
+        assembly = Assembly.LoadFile(afterAssemblyPath);
+    }
+
+    [Test]
+    public void ClassWithPrivateEmptyConstructor_MustNotBeAbleToConstruct()
+    {
+        var type = assembly.GetType("ClassWithPrivateConstructor", true);
+        Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(type));
+    }
+
+    [Test]
+    public void ClassWithPrivateEmptyConstructor_MustHaveCorrectAccessModifier()
+    {
+        var type = assembly.GetType("ClassWithPrivateConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsFalse(constructorInfo.IsPrivate);
+        Assert.IsTrue(constructorInfo.IsFamily);
+        Assert.IsFalse(constructorInfo.IsPublic);
+    }
+
+    [Test]
+    public void ClassWithProtectedEmptyConstructor_MustNotBeAbleToConstruct()
+    {
+        var type = assembly.GetType("ClassWithProtectedConstructor", true);
+        Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(type));
+    }
+
+    [Test]
+    public void ClassWithProtectedEmptyConstructor_MustHaveCorrectAccessModifier()
+    {
+        var type = assembly.GetType("ClassWithProtectedConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsFalse(constructorInfo.IsPrivate);
+        Assert.IsTrue(constructorInfo.IsFamily);
+        Assert.IsFalse(constructorInfo.IsPublic);
+    }
+
+    [Test]
+    public void ClassAbstractWithPrivateEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassAbstractWithPrivateConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsFalse(constructorInfo.IsFamily);
+        Assert.IsFalse(constructorInfo.IsPublic);
+    }
+
+    [Test]
+    public void ClassAbstractWithProtectedEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassAbstractWithProtectedConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsTrue(constructorInfo.IsFamily);
+        Assert.IsFalse(constructorInfo.IsPublic);
+    }
+}

--- a/Tests/MakeExistingEmptyConstructorsPublicIntegrationTests.cs
+++ b/Tests/MakeExistingEmptyConstructorsPublicIntegrationTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+using NUnit.Framework;
+using MethodAttributes = Mono.Cecil.MethodAttributes;
+
+[TestFixture]
+public class MakeExistingEmptyConstructorsPublicIntegrationTests
+{
+    Assembly assembly;
+    List<string> warnings = new List<string>();
+    string beforeAssemblyPath;
+    string afterAssemblyPath;
+
+    public MakeExistingEmptyConstructorsPublicIntegrationTests()
+    {
+        beforeAssemblyPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, @"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll"));
+#if (!DEBUG)
+        beforeAssemblyPath = beforeAssemblyPath.Replace("Debug", "Release");
+#endif
+
+        afterAssemblyPath = beforeAssemblyPath.Replace(".dll", "6.dll");
+        File.Copy(beforeAssemblyPath, afterAssemblyPath, true);
+
+        var assemblyResolver = new MockAssemblyResolver
+        {
+            Directory = Path.GetDirectoryName(beforeAssemblyPath)
+        };
+        using (var moduleDefinition = ModuleDefinition.ReadModule(beforeAssemblyPath, new ReaderParameters
+        {
+            AssemblyResolver = assemblyResolver
+        }))
+        {
+            var weavingTask = new ModuleWeaver
+            {
+                ModuleDefinition = moduleDefinition,
+                AssemblyResolver = assemblyResolver,
+                LogWarning = s => warnings.Add(s),
+                Visibility = MethodAttributes.Public,
+                MakeExistingEmptyConstructorsVisible = true
+            };
+
+            weavingTask.Execute();
+            moduleDefinition.Write(afterAssemblyPath);
+        }
+
+        assembly = Assembly.LoadFile(afterAssemblyPath);
+    }
+    
+    [Test]
+    public void ClassWithPrivateEmptyConstructor_MustBeAbleToConstruct()
+    {
+        var type = assembly.GetType("ClassWithPrivateConstructor", true);
+        Activator.CreateInstance(type);
+    }
+
+    [Test]
+    public void ClassWithPrivateEmptyConstructor_MustHaveCorrectAccessModifier()
+    {
+        var type = assembly.GetType("ClassWithPrivateConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsFalse(constructorInfo.IsPrivate);
+        Assert.IsFalse(constructorInfo.IsFamily);
+        Assert.IsTrue(constructorInfo.IsPublic);
+    }
+
+    [Test]
+    public void ClassWithProtectedEmptyConstructor_MustBeAbleToConstruct()
+    {
+        var type = assembly.GetType("ClassWithProtectedConstructor", true);
+        Activator.CreateInstance(type);
+    }
+
+    [Test]
+    public void ClassWithProtectedEmptyConstructor_MustHaveCorrectAccessModifier()
+    {
+        var type = assembly.GetType("ClassWithProtectedConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsFalse(constructorInfo.IsPrivate);
+        Assert.IsFalse(constructorInfo.IsFamily);
+        Assert.IsTrue(constructorInfo.IsPublic);
+    }
+    
+    [Test]
+    public void ClassAbstractWithPrivateEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassAbstractWithPrivateConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsFalse(constructorInfo.IsFamily);
+        Assert.IsFalse(constructorInfo.IsPublic);
+    }
+
+    [Test]
+    public void ClassAbstractWithProtectedEmptyConstructor()
+    {
+        var type = assembly.GetType("ClassAbstractWithProtectedConstructor", true);
+        var constructorInfo = type
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            .Single(x => x.GetParameters().Length == 0);
+
+        Assert.IsTrue(constructorInfo.IsFamily);
+        Assert.IsFalse(constructorInfo.IsPublic);
+    }
+}

--- a/Tests/TestHelpers/Verifier.cs
+++ b/Tests/TestHelpers/Verifier.cs
@@ -1,26 +1,44 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Utilities;
 using NUnit.Framework;
 
 public static class Verifier
 {
+    static string exePath;
+    static bool peverifyFound;
+
+    static Verifier()
+    {
+        var sdkPath = Path.GetFullPath(Path.Combine(ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.VersionLatest), "..\\.."));
+        exePath = Directory.GetFiles(sdkPath, "peverify.exe", SearchOption.AllDirectories).LastOrDefault();
+
+        peverifyFound = File.Exists(exePath);
+        if (!peverifyFound)
+        {
+#if(!DEBUG)
+            throw new System.Exception("Could not find PEVerify");
+#endif
+        }
+    }
     public static void Verify(string beforeAssemblyPath, string afterAssemblyPath)
     {
+        if (!peverifyFound)
+        {
+            return;
+        }
+        Debug.WriteLine(afterAssemblyPath);
         var before = Validate(beforeAssemblyPath);
         var after = Validate(afterAssemblyPath);
         var message = $"Failed processing {Path.GetFileName(afterAssemblyPath)}\r\n{after}";
         Assert.AreEqual(TrimLineNumbers(before), TrimLineNumbers(after), message);
     }
 
-    static string Validate(string assemblyPath2)
+    public static string Validate(string assemblyPath2)
     {
-        var exePath = GetPathToPEVerify();
-        if (!File.Exists(exePath))
-        {
-            return string.Empty;
-        }
+
         var process = Process.Start(new ProcessStartInfo(exePath, "\"" + assemblyPath2 + "\"")
         {
             RedirectStandardOutput = true,
@@ -30,17 +48,6 @@ public static class Verifier
 
         process.WaitForExit(10000);
         return process.StandardOutput.ReadToEnd().Trim().Replace(assemblyPath2, "");
-    }
-
-    static string GetPathToPEVerify()
-    {
-        var exePath = Environment.ExpandEnvironmentVariables(@"%programfiles(x86)%\Microsoft SDKs\Windows\v7.0A\Bin\NETFX 4.0 Tools\PEVerify.exe");
-
-        if (!File.Exists(exePath))
-        {
-            exePath = Environment.ExpandEnvironmentVariables(@"%programfiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\PEVerify.exe");
-        }
-        return exePath;
     }
 
     static string TrimLineNumbers(string foo)

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -30,33 +30,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyToReference\AssemblyToReference.csproj">
@@ -70,6 +63,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigReaderTests.cs" />
+    <Compile Include="MakeExistingEmptyConstructorsFamilyIntegrationTests.cs" />
+    <Compile Include="MakeExistingEmptyConstructorsPublicIntegrationTests.cs" />
     <Compile Include="IntegrationTests.cs" />
     <Compile Include="LineMatcherTest.cs" />
     <Compile Include="TestHelpers\AssemblyExtensions.cs" />
@@ -77,6 +72,9 @@
     <Compile Include="TestHelpers\Verifier.cs" />
     <Compile Include="WithExcludesTests.cs" />
     <Compile Include="WithIncludesTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FodyCecil" version="2.0.0" targetFramework="net452" developmentDependency="true" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="FodyCecil" version="2.1.2" targetFramework="net452" developmentDependency="true" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
-updated all nuget package references
-updated Verifier (copied from PropertyChanged.Fody)
-added possibility to make existing empty constructors more visible (opt-in feature)
-updated ReadMe
-bumped version from 1.2.1 to 1.3.0