### PR TITLE
Added missing integration tests for generics

### DIFF
--- a/AssemblyToProcess/ClassWithGeneric.cs
+++ b/AssemblyToProcess/ClassWithGeneric.cs
@@ -19,7 +19,6 @@ public class ClassWithGenericInheritWithGeneric<T> : ClassWithGeneric<T>
     protected ClassWithGenericInheritWithGeneric(T x)
     : base(x)
     {
-
     }
 }
 

--- a/AssemblyToProcess/ClassWithGeneric.cs
+++ b/AssemblyToProcess/ClassWithGeneric.cs
@@ -1,11 +1,32 @@
 public class ClassWithGeneric<T>
 {
+    protected ClassWithGeneric(T x)
+    {
+    }
 }
 
 public class ClassInheritWithGeneric : ClassWithGeneric<string>
 {
-// ReSharper disable once UnusedParameter.Local
+    // ReSharper disable once UnusedParameter.Local
     public ClassInheritWithGeneric(string x)
+    : base(x)
+    {
+    }
+}
+
+public class ClassWithGenericInheritWithGeneric<T> : ClassWithGeneric<T>
+{
+    protected ClassWithGenericInheritWithGeneric(T x)
+    : base(x)
+    {
+
+    }
+}
+
+public class ClassInheritWithGenericInheritWithGeneric : ClassWithGenericInheritWithGeneric<string>
+{
+    public ClassInheritWithGenericInheritWithGeneric(string x)
+    : base(x)
     {
     }
 }

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -115,4 +115,28 @@ public class IntegrationTests
         Assert.True(constructorInfo.IsFamily);
         Assert.False(constructorInfo.IsPublic);
     }
+
+    [Fact]
+    public void ClassWithGeneric()
+    {
+        testResult.GetGenericInstance("ClassWithGeneric`1", typeof(string));
+    }
+
+    [Fact]
+    public void ClassInheritWithGeneric()
+    {
+        testResult.GetInstance("ClassInheritWithGeneric");
+    }
+
+    [Fact]
+    public void ClassWithGenericInheritWithGeneric()
+    {
+        testResult.GetGenericInstance("ClassWithGenericInheritWithGeneric`1", typeof(object));
+    }
+
+    [Fact]
+    public void ClassInheritWithGenericInheritWithGeneric()
+    {
+        testResult.GetInstance("ClassInheritWithGenericInheritWithGeneric");
+    }
 }


### PR DESCRIPTION
#### Description
AssemblyToProcess already contains classes with generics (see `ClassWithGeneric`). The were not used in the Integration Tests however.

#### The solution

I've added tests for the existing classes and also for some new variants:

- class is generic and inherits from generic class
- class inherits from a generic class which inherits from a generic class

#### Todos

 * [x] Related issues -- repo doesn't have any open issues.
 * [x] Tests -- were created
 * [x] Documentation -- does not affect documentation