### PR TITLE
Fix #42: Class Sequence breaks adding Empty Constructor to Class inheriting from Generic Class

### DIFF
--- a/AssemblyToProcess/ClassInheritGenericWithEmptyConstructorFromOtherAssembly.cs
+++ b/AssemblyToProcess/ClassInheritGenericWithEmptyConstructorFromOtherAssembly.cs
@@ -1,0 +1,3 @@
+public class ClassInheritGenericWithEmptyConstructorFromOtherAssembly : AssemblyToReference.GenericClassWithEmptyConstructor<string>
+{
+}

--- a/AssemblyToProcess/ClassInheritGenericWithNonEmptyConstructorFromOtherAssembly.cs
+++ b/AssemblyToProcess/ClassInheritGenericWithNonEmptyConstructorFromOtherAssembly.cs
@@ -1,0 +1,7 @@
+public class ClassInheritGenericWithNonEmptyConstructorFromOtherAssembly : AssemblyToReference.GenericClassWithNonEmptyConstructor<int>
+{
+    public ClassInheritGenericWithNonEmptyConstructorFromOtherAssembly(int x)
+        : base(x)
+    {
+    }
+}

--- a/AssemblyToProcess/ClassInheritWithGenericInReverseDeclarationOrder.cs
+++ b/AssemblyToProcess/ClassInheritWithGenericInReverseDeclarationOrder.cs
@@ -1,0 +1,17 @@
+// This is a repro for #42 "Class Sequence breaks adding Empty Constructor to Class inheriting from Generic Class" (https://github.com/Fody/EmptyConstructor/issues/42)
+// WARNING: do not change the sequence of the classes in this file as the sequence is critical (it determines the sequence the weavers processes classes).
+// Also, do not extract a class from this file.
+public class ClassInheritWithGenericInReverseDeclarationOrder : ClassWithGenericInReverseDeclarationOrder<string>
+{
+    public ClassInheritWithGenericInReverseDeclarationOrder(string x)
+    : base(x)
+    {
+    }
+}
+
+public class ClassWithGenericInReverseDeclarationOrder<T>
+{
+    protected ClassWithGenericInReverseDeclarationOrder(T x)
+    {
+    }
+}

--- a/AssemblyToReference/GenericClassWithEmptyConstructor.cs
+++ b/AssemblyToReference/GenericClassWithEmptyConstructor.cs
@@ -1,0 +1,6 @@
+namespace AssemblyToReference
+{
+    public class GenericClassWithEmptyConstructor<T>
+    {
+    }
+}

--- a/AssemblyToReference/GenericClassWithNonEmptyConstructor.cs
+++ b/AssemblyToReference/GenericClassWithNonEmptyConstructor.cs
@@ -1,0 +1,10 @@
+namespace AssemblyToReference
+{
+    public class GenericClassWithNonEmptyConstructor<T>
+    {
+        // ReSharper disable once UnusedParameter.Local
+        public GenericClassWithNonEmptyConstructor(T x)
+        {
+        }
+    }
+}

--- a/EmptyConstructor.Fody/ModuleWeaver.cs
+++ b/EmptyConstructor.Fody/ModuleWeaver.cs
@@ -71,7 +71,7 @@ public partial class ModuleWeaver:BaseModuleWeaver
             {
                 if (!external.TryGetValue(baseType, out baseEmptyConstructor))
                 {
-                    var emptyConstructor = baseType.Resolve().GetEmptyConstructor();
+                    var emptyConstructor = baseTypeDefinition.GetEmptyConstructor();
                     if (emptyConstructor != null)
                     {
                         baseEmptyConstructor = ModuleDefinition.ImportReference(emptyConstructor);

--- a/EmptyConstructor.Fody/ModuleWeaver.cs
+++ b/EmptyConstructor.Fody/ModuleWeaver.cs
@@ -82,7 +82,7 @@ public partial class ModuleWeaver:BaseModuleWeaver
                 if (baseEmptyConstructor == null)
                 {
                     processed.Add(type, null);
-                    LogDebug($"COuld not inject empty constructor in {type.FullName} because base class does not have a parameterless constructor and is from an external assembly");
+                    LogDebug($"Could not inject empty constructor in {type.FullName} because base class does not have a parameterless constructor and is from an external assembly");
                     continue;
                 }
             }

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -31,6 +31,24 @@ public class IntegrationTests
     }
 
     [Fact]
+    public void ClassInheritGenericWithEmptyConstructorFromOtherAssembly()
+    {
+        testResult.GetInstance("ClassInheritGenericWithEmptyConstructorFromOtherAssembly");
+    }
+
+    [Fact]
+    public void ClassInheritWithNonEmptyConstructorFromOtherAssembly()
+    {
+        Assert.Throws<MissingMethodException>(() => testResult.GetInstance("ClassInheritWithNonEmptyConstructorFromOtherAssembly"));
+    }
+
+    [Fact]
+    public void ClassInheritGenericWithNonEmptyConstructorFromOtherAssembly()
+    {
+        Assert.Throws<MissingMethodException>(() => testResult.GetInstance("ClassInheritGenericWithNonEmptyConstructorFromOtherAssembly"));
+    }
+
+    [Fact]
     public void ClassInheritAbstractWithEmptyConstructor()
     {
         testResult.GetInstance("ClassInheritAbstractWithEmptyConstructor");

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -21,7 +21,7 @@ public class IntegrationTests
     [Fact]
     public void ClassInheritWithBothConstructors()
     {
-       testResult.GetInstance("ClassInheritWithBothConstructors");
+        testResult.GetInstance("ClassInheritWithBothConstructors");
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class IntegrationTests
     public void ClassWithDefaultSingleParamConstructor()
     {
         var type = assembly.GetType("ClassWithDefaultSingleParamConstructor", true);
-        Assert.Equal(2,type.GetConstructors().Length);
-        Activator.CreateInstance(type,"aString");
+        Assert.Equal(2, type.GetConstructors().Length);
+        Activator.CreateInstance(type, "aString");
     }
 
     [Fact]

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -139,4 +139,16 @@ public class IntegrationTests
     {
         testResult.GetInstance("ClassInheritWithGenericInheritWithGeneric");
     }
+
+    [Fact]
+    public void ClassWithGenericInReverseDeclarationOrder()
+    {
+        testResult.GetGenericInstance("ClassWithGenericInReverseDeclarationOrder`1", typeof(object));
+    }
+
+    [Fact]
+    public void ClassInheritWithGenericInReverseDeclarationOrder()
+    {
+        testResult.GetInstance("ClassInheritWithGenericInReverseDeclarationOrder");
+    }
 }


### PR DESCRIPTION
#### Description

This fixes #42 

#### The solution

* always perform `TypeDefinition.BaseType.Resolve();` to handle generic types properly
* properly implement distinction of internal vs external (other assembly) types by comparing resolved base type against an initially created list `var internalTypes = ModuleDefinition.GetTypes().ToList();`
* added debug log output for external base types which do not have a parameterless constructor

#### Todos

 * [x] Implementation
 * [x] Related issues - close #42 when merging this to master
 * [x] Tests - `ClassInheritWithGenericInReverseDeclarationOrder`
 * [x] Documentation - Since closed issue serves as "change notes" I believe there is no further documentation necessary.