### PR TITLE
Property & field initializers is now preserved in generated constructor.

### DIFF
--- a/AssemblyToProcess/ClassWithInitializedProperties.cs
+++ b/AssemblyToProcess/ClassWithInitializedProperties.cs
@@ -1,0 +1,11 @@
+public class ClassWithInitializedProperties : ClassWithNoEmptyConstructor
+{
+    public int X { get; } = 9;
+    public string Y { get; } = "aString";
+    public Simple Z { get; } = new Simple(1);
+
+    public ClassWithInitializedProperties(string x)
+        : base(x)
+    {
+    }
+}

--- a/EmptyConstructor.Fody/ConfigReader.cs
+++ b/EmptyConstructor.Fody/ConfigReader.cs
@@ -30,7 +30,7 @@ public partial class ModuleWeaver
 
     void ReadInitializersPreserving()
     {
-        var attribute = Config.Attribute("PreserveInitializers");
+        var attribute = Config.Attribute("DoNotPreserveInitializers");
         if (attribute == null)
         {
             return;
@@ -38,13 +38,13 @@ public partial class ModuleWeaver
 
         if (string.Compare(attribute.Value, "true", StringComparison.OrdinalIgnoreCase) == 0)
         {
-            PreserveInitializers = true;
+            DoNotPreserveInitializers = true;
             return;
         }
 
         if (string.Compare(attribute.Value, "false", StringComparison.OrdinalIgnoreCase) == 0)
         {
-            PreserveInitializers = false;
+            DoNotPreserveInitializers = false;
             return;
         }
 

--- a/EmptyConstructor.Fody/ConfigReader.cs
+++ b/EmptyConstructor.Fody/ConfigReader.cs
@@ -20,11 +20,36 @@ public partial class ModuleWeaver
         ReadMakeExistingEmptyConstructorsVisible();
         ReadExcludes();
         ReadIncludes();
+        ReadInitializersPreserving();
 
         if (IncludeNamespaces.Any() && ExcludeNamespaces.Any())
         {
             throw new WeavingException("Either configure IncludeNamespaces OR ExcludeNamespaces, not both.");
         }
+    }
+
+    void ReadInitializersPreserving()
+    {
+        var attribute = Config.Attribute("PreserveInitializers");
+        if (attribute == null)
+        {
+            return;
+        }
+
+        if (string.Compare(attribute.Value, "true", StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            PreserveInitializers = true;
+            return;
+        }
+
+        if (string.Compare(attribute.Value, "false", StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            PreserveInitializers = false;
+            return;
+        }
+
+        var message = $"Could not convert '{attribute.Value}' to a boolean. Only 'true' or 'false' are allowed.";
+        throw new WeavingException(message);
     }
 
     void ReadVisibility()

--- a/EmptyConstructor.Fody/ModuleWeaver.cs
+++ b/EmptyConstructor.Fody/ModuleWeaver.cs
@@ -9,7 +9,7 @@ public partial class ModuleWeaver:BaseModuleWeaver
 {
     public MethodAttributes Visibility = MethodAttributes.Public;
     public bool MakeExistingEmptyConstructorsVisible;
-    public bool PreserveInitializers = true;
+    public bool DoNotPreserveInitializers;
 
     public override void Execute()
     {
@@ -135,7 +135,7 @@ public partial class ModuleWeaver:BaseModuleWeaver
 
     void TryInjectPropertyOrFieldInitializers(TypeDefinition type, MethodDefinition method)
     {
-        if (!PreserveInitializers)
+        if (DoNotPreserveInitializers)
         {
             return;
         }

--- a/EmptyConstructor.Fody/ModuleWeaver.cs
+++ b/EmptyConstructor.Fody/ModuleWeaver.cs
@@ -3,11 +3,13 @@ using System.Linq;
 using Fody;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 
 public partial class ModuleWeaver:BaseModuleWeaver
 {
     public MethodAttributes Visibility = MethodAttributes.Public;
     public bool MakeExistingEmptyConstructorsVisible;
+    public bool PreserveInitializers = true;
 
     public override void Execute()
     {
@@ -117,14 +119,57 @@ public partial class ModuleWeaver:BaseModuleWeaver
     MethodDefinition AddEmptyConstructor(TypeDefinition type)
     {
         LogDebug("Processing " + type.FullName);
+
         var methodAttributes = Visibility | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName;
         var method = new MethodDefinition(".ctor", methodAttributes, TypeSystem.VoidReference);
+
+        TryInjectPropertyOrFieldInitializers(type, method);
+        
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
         var methodReference = new MethodReference(".ctor", TypeSystem.VoidReference, type.BaseType){HasThis = true};
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Call, methodReference));
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
         type.Methods.Add(method);
         return method;
+    }
+
+    void TryInjectPropertyOrFieldInitializers(TypeDefinition type, MethodDefinition method)
+    {
+        if (!PreserveInitializers)
+        {
+            return;
+        }
+
+        var existingConstructor = type.GetConstructors().FirstOrDefault();
+        if (existingConstructor != null) // any constructor exists - try to clone its initializers part (should be before calling base.ctor())
+        {
+            var initializerInstructions = existingConstructor
+                .Body
+                .Instructions
+                .TakeWhile(i => !IsBaseConstructorCallInstruction(i, type))
+                .Reverse() // cut also instructions preparing constructor call
+                .SkipWhile(i => !IsLdArg0Instruction(i)) // first of them should be ldarg.0
+                .Skip(1) // skip also ldarg.0
+                .Reverse();
+
+            foreach (var instruction in initializerInstructions)
+            {
+                method.Body.Instructions.Add(instruction);
+            }
+        }
+    }
+
+    static bool IsLdArg0Instruction(Instruction instruction)
+    {
+        return instruction.OpCode == OpCodes.Ldarg_0;
+    }
+
+    static bool IsBaseConstructorCallInstruction(Instruction instruction, TypeDefinition type)
+    {
+        return instruction.OpCode == OpCodes.Call
+               && instruction.Operand is MethodReference methodReference
+               && methodReference.DeclaringType == type.BaseType
+               && methodReference.Name == ".ctor";
     }
 
     void MakeConstructorVisibleIfConfiguredAndNecessary(MethodDefinition typeEmptyConstructor)

--- a/EmptyConstructor.sln.DotSettings
+++ b/EmptyConstructor.sln.DotSettings
@@ -611,4 +611,5 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	
 	
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
-	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Initializers/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Tests/ConfigReaderTests.cs
+++ b/Tests/ConfigReaderTests.cs
@@ -86,25 +86,25 @@ Foo.Bar
         var xElement = XElement.Parse("<EmptyConstructor/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ReadConfig();
-        Assert.True(moduleWeaver.PreserveInitializers);
+        Assert.False(moduleWeaver.DoNotPreserveInitializers);
     }
 
     [Fact]
     public void PreserveInitializers_False()
     {
-        var xElement = XElement.Parse("<EmptyConstructor PreserveInitializers='False'/>");
+        var xElement = XElement.Parse("<EmptyConstructor DoNotPreserveInitializers='False'/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ReadConfig();
-        Assert.False(moduleWeaver.PreserveInitializers);
+        Assert.False(moduleWeaver.DoNotPreserveInitializers);
     }
 
     [Fact]
     public void PreserveInitializers_True()
     {
-        var xElement = XElement.Parse("<EmptyConstructor PreserveInitializers='True'/>");
+        var xElement = XElement.Parse("<EmptyConstructor DoNotPreserveInitializers='True'/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ReadConfig();
-        Assert.True(moduleWeaver.PreserveInitializers);
+        Assert.True(moduleWeaver.DoNotPreserveInitializers);
     }
 
     [Fact]

--- a/Tests/ConfigReaderTests.cs
+++ b/Tests/ConfigReaderTests.cs
@@ -81,6 +81,33 @@ Foo.Bar
     }
 
     [Fact]
+    public void PreserveInitializers_Default()
+    {
+        var xElement = XElement.Parse("<EmptyConstructor/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ReadConfig();
+        Assert.True(moduleWeaver.PreserveInitializers);
+    }
+
+    [Fact]
+    public void PreserveInitializers_False()
+    {
+        var xElement = XElement.Parse("<EmptyConstructor PreserveInitializers='False'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ReadConfig();
+        Assert.False(moduleWeaver.PreserveInitializers);
+    }
+
+    [Fact]
+    public void PreserveInitializers_True()
+    {
+        var xElement = XElement.Parse("<EmptyConstructor PreserveInitializers='True'/>");
+        var moduleWeaver = new ModuleWeaver { Config = xElement };
+        moduleWeaver.ReadConfig();
+        Assert.True(moduleWeaver.PreserveInitializers);
+    }
+
+    [Fact]
     public void ExcludeNamespacesAttribute()
     {
         var xElement = XElement.Parse(@"

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -163,6 +163,24 @@ public class IntegrationTests :
         testResult.GetInstance("ClassInheritWithGenericInReverseDeclarationOrder");
     }
 
+    [Fact]
+    public void ClassWithInitializedFields()
+    {
+        var instance = testResult.GetInstance("ClassWithInitializedFields");
+        Assert.Equal(9, instance.X);
+        Assert.Equal("aString", instance.Y);
+        Assert.NotNull(instance.Z);
+    }
+
+    [Fact]
+    public void ClassWithInitializedProperties()
+    {
+        var instance = testResult.GetInstance("ClassWithInitializedProperties");
+        Assert.Equal(9, instance.X);
+        Assert.Equal("aString", instance.Y);
+        Assert.NotNull(instance.Z);
+    }
+
     public IntegrationTests(ITestOutputHelper output) : 
         base(output)
     {

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,14 @@ Or as a attribute with items delimited by a pipe `|`.
 <EmptyConstructor IncludeNamespaces='Foo|Bar'/>
 ```
 
+### Initializers preserving
+
+By default, field & property initializers are called when generated constructor is called (behaves like default constructor is handwritten). This behavior can be disabled by `DoNotPreserveInitializers` attribute.
+
+```xml
+<EmptyConstructor DoNotPreserveInitializers='false'/>
+```
+
 
 ## Icon
 

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ Or as a attribute with items delimited by a pipe `|`.
 By default, field & property initializers are called when generated constructor is called (behaves like default constructor is handwritten). This behavior can be disabled by `DoNotPreserveInitializers` attribute.
 
 ```xml
-<EmptyConstructor DoNotPreserveInitializers='false'/>
+<EmptyConstructor DoNotPreserveInitializers='true'/>
 ```
 
 


### PR DESCRIPTION
Solves [this issue](https://github.com/Fody/EmptyConstructor/issues/132).

Generated constructor now contains property & field initializers. They are copied from existing constructor according to [this description of how C# compiler compiles them](https://stackoverflow.com/a/40139749).

Behavior is on by default and can be turned off by setting "PreserveInitializers" config to false.