### PR TITLE
Reproduce Bug #143

### DIFF
--- a/AssemblyToProcess/ReproBug143.cs
+++ b/AssemblyToProcess/ReproBug143.cs
@@ -1,0 +1,18 @@
+public class Bug143Child : Bug143Base<int>
+{
+    #pragma warning disable CS0414
+    bool value;
+
+    private Bug143Child(int enumValue)
+        : base(enumValue)
+    {
+        value = true;
+    }
+}
+
+public abstract class Bug143Base<TValue>
+{
+    protected Bug143Base(TValue value)
+    {
+    }
+}

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -181,7 +181,14 @@ public class IntegrationTests :
         Assert.NotNull(instance.Z);
     }
 
-    public IntegrationTests(ITestOutputHelper output) : 
+    [Fact]
+    public void ReproBug143()
+    {
+        var instance = testResult.GetInstance("Bug143Child");
+        Assert.NotNull(instance);
+    }
+
+    public IntegrationTests(ITestOutputHelper output) :
         base(output)
     {
     }


### PR DESCRIPTION
This reproduces #143 

PEVerify fails with:
> Bug143Child::.ctor] Unrecognized argument number.(Error: 0x80131868)