### PR TITLE
Make Field Initialization Opt-In

### DIFF
--- a/EmptyConstructor.Fody/ConfigReader.cs
+++ b/EmptyConstructor.Fody/ConfigReader.cs
@@ -30,26 +30,7 @@ public partial class ModuleWeaver
 
     void ReadInitializersPreserving()
     {
-        var attribute = Config.Attribute("DoNotPreserveInitializers");
-        if (attribute == null)
-        {
-            return;
-        }
-
-        if (string.Compare(attribute.Value, "true", StringComparison.OrdinalIgnoreCase) == 0)
-        {
-            DoNotPreserveInitializers = true;
-            return;
-        }
-
-        if (string.Compare(attribute.Value, "false", StringComparison.OrdinalIgnoreCase) == 0)
-        {
-            DoNotPreserveInitializers = false;
-            return;
-        }
-
-        var message = $"Could not convert '{attribute.Value}' to a boolean. Only 'true' or 'false' are allowed.";
-        throw new WeavingException(message);
+        TryReadBooleanAttribute("PreserveInitializers", ref PreserveInitializers);
     }
 
     void ReadVisibility()
@@ -78,26 +59,7 @@ public partial class ModuleWeaver
 
     void ReadMakeExistingEmptyConstructorsVisible()
     {
-        var attribute = Config.Attribute("MakeExistingEmptyConstructorsVisible");
-        if (attribute == null)
-        {
-            return;
-        }
-
-        if (string.Compare(attribute.Value, "true", StringComparison.OrdinalIgnoreCase) == 0)
-        {
-            MakeExistingEmptyConstructorsVisible = true;
-            return;
-        }
-
-        if (string.Compare(attribute.Value, "false", StringComparison.OrdinalIgnoreCase) == 0)
-        {
-            MakeExistingEmptyConstructorsVisible = false;
-            return;
-        }
-
-        var message = $"Could not convert '{attribute.Value}' to a boolean. Only 'true' or 'false' are allowed.";
-        throw new WeavingException(message);
+        TryReadBooleanAttribute("MakeExistingEmptyConstructorsVisible", ref MakeExistingEmptyConstructorsVisible);
     }
 
     void ReadExcludes()
@@ -156,5 +118,29 @@ public partial class ModuleWeaver
         {
             IncludeNamespaces.Add(item);
         }
+    }
+
+    void TryReadBooleanAttribute(string attributeName, ref bool value)
+    {
+        var attribute = Config.Attribute(attributeName);
+        if (attribute == null)
+        {
+            return;
+        }
+
+        if (string.Compare(attribute.Value, "true", StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            value = true;
+            return;
+        }
+
+        if (string.Compare(attribute.Value, "false", StringComparison.OrdinalIgnoreCase) == 0)
+        {
+            value = false;
+            return;
+        }
+
+        var message = $"Could not convert {attributeName}='{attribute.Value}' to a boolean. Only 'true' or 'false' are allowed.";
+        throw new WeavingException(message);
     }
 }

--- a/EmptyConstructor.Fody/ModuleWeaver.cs
+++ b/EmptyConstructor.Fody/ModuleWeaver.cs
@@ -9,7 +9,7 @@ public partial class ModuleWeaver:BaseModuleWeaver
 {
     public MethodAttributes Visibility = MethodAttributes.Public;
     public bool MakeExistingEmptyConstructorsVisible;
-    public bool DoNotPreserveInitializers;
+    public bool PreserveInitializers;
 
     public override void Execute()
     {
@@ -124,7 +124,7 @@ public partial class ModuleWeaver:BaseModuleWeaver
         var method = new MethodDefinition(".ctor", methodAttributes, TypeSystem.VoidReference);
 
         TryInjectPropertyOrFieldInitializers(type, method);
-        
+
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldarg_0));
         var methodReference = new MethodReference(".ctor", TypeSystem.VoidReference, type.BaseType){HasThis = true};
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Call, methodReference));
@@ -135,7 +135,7 @@ public partial class ModuleWeaver:BaseModuleWeaver
 
     void TryInjectPropertyOrFieldInitializers(TypeDefinition type, MethodDefinition method)
     {
-        if (DoNotPreserveInitializers)
+        if (!PreserveInitializers)
         {
             return;
         }

--- a/Tests/ConfigReaderTests.cs
+++ b/Tests/ConfigReaderTests.cs
@@ -86,25 +86,25 @@ Foo.Bar
         var xElement = XElement.Parse("<EmptyConstructor/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ReadConfig();
-        Assert.False(moduleWeaver.DoNotPreserveInitializers);
+        Assert.False(moduleWeaver.PreserveInitializers);
     }
 
     [Fact]
     public void PreserveInitializers_False()
     {
-        var xElement = XElement.Parse("<EmptyConstructor DoNotPreserveInitializers='False'/>");
+        var xElement = XElement.Parse("<EmptyConstructor PreserveInitializers='False'/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ReadConfig();
-        Assert.False(moduleWeaver.DoNotPreserveInitializers);
+        Assert.False(moduleWeaver.PreserveInitializers);
     }
 
     [Fact]
     public void PreserveInitializers_True()
     {
-        var xElement = XElement.Parse("<EmptyConstructor DoNotPreserveInitializers='True'/>");
+        var xElement = XElement.Parse("<EmptyConstructor PreserveInitializers='True'/>");
         var moduleWeaver = new ModuleWeaver { Config = xElement };
         moduleWeaver.ReadConfig();
-        Assert.True(moduleWeaver.DoNotPreserveInitializers);
+        Assert.True(moduleWeaver.PreserveInitializers);
     }
 
     [Fact]

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -167,21 +167,21 @@ public class IntegrationTests :
     public void ClassWithInitializedFields()
     {
         var instance = testResult.GetInstance("ClassWithInitializedFields");
-        Assert.Equal(9, instance.X);
-        Assert.Equal("aString", instance.Y);
-        Assert.NotNull(instance.Z);
+        Assert.Equal(0, instance.X);
+        Assert.Equal(null, instance.Y);
+        Assert.Null(instance.Z);
     }
 
     [Fact]
     public void ClassWithInitializedProperties()
     {
         var instance = testResult.GetInstance("ClassWithInitializedProperties");
-        Assert.Equal(9, instance.X);
-        Assert.Equal("aString", instance.Y);
-        Assert.NotNull(instance.Z);
+        Assert.Equal(0, instance.X);
+        Assert.Equal(null, instance.Y);
+        Assert.Null(instance.Z);
     }
 
-    public IntegrationTests(ITestOutputHelper output) : 
+    public IntegrationTests(ITestOutputHelper output) :
         base(output)
     {
     }

--- a/Tests/PreserveInitializersIntegrationTests.cs
+++ b/Tests/PreserveInitializersIntegrationTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Fody;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+public class PreserveInitializersIntegrationTests :
+    VerifyBase
+{
+    static Assembly assembly;
+    static TestResult testResult;
+
+    static PreserveInitializersIntegrationTests()
+    {
+        var weavingTask = new ModuleWeaver
+        {
+            PreserveInitializers = true
+        };
+        testResult = weavingTask.ExecuteTestRun("AssemblyToProcess.dll",
+            assemblyName: nameof(MakeExistingEmptyConstructorsFamilyIntegrationTests));
+        assembly = testResult.Assembly;
+    }
+
+    [Fact]
+    public void ClassWithInitializedFields()
+    {
+        var instance = testResult.GetInstance("ClassWithInitializedFields");
+        Assert.Equal(9, instance.X);
+        Assert.Equal("aString", instance.Y);
+        Assert.NotNull(instance.Z);
+    }
+
+    [Fact]
+    public void ClassWithInitializedProperties()
+    {
+        var instance = testResult.GetInstance("ClassWithInitializedProperties");
+        Assert.Equal(9, instance.X);
+        Assert.Equal("aString", instance.Y);
+        Assert.NotNull(instance.Z);
+    }
+
+    public PreserveInitializersIntegrationTests(ITestOutputHelper output) :
+        base(output)
+    {
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -152,14 +152,51 @@ Or as a attribute with items delimited by a pipe `|`.
 <EmptyConstructor IncludeNamespaces='Foo|Bar'/>
 ```
 
-### Initializers preserving
+### Initializers Preservation
 
-By default, field & property initializers are called when generated constructor is called (behaves like default constructor is handwritten). This behavior can be disabled by `DoNotPreserveInitializers` attribute.
+By default, the generated constructors remain empty. If you would like field & property initialization to be copied from an existing constructor enable this via the `PreserveInitializers` attribute.
 
 ```xml
-<EmptyConstructor DoNotPreserveInitializers='true'/>
+<EmptyConstructor PreserveInitializers='true'/>
 ```
 
+Example, without initializers preservation:
+
+    public class Foo
+    {
+        private int someValue;
+        private int otherValue;
+        
+        public Foo(int someValue)
+        {
+          this.someValue = someValue;
+          otherValue = 17;
+        }
+        
+        // generated constructor
+        public Foo() { }
+    }
+
+Example, with initializers preservation:
+
+    public class Foo
+    {
+        private int someValue;
+        private int otherValue;
+        
+        public Foo(int someValue)
+        {
+          this.someValue = someValue;
+          otherValue = 17;
+        }
+        
+        // generated constructor
+        public Foo()
+        {
+            // note: this.someValue isn't set
+            otherValue = 17;
+        }
+    }
 
 ## Icon
 


### PR DESCRIPTION
#### Description

This makes [field/property initialization](https://github.com/Fody/EmptyConstructor/pull/133) opt-in instead of opt-out.

It is a **breaking change**, as it replaces the `DoNotPreserveInitializers` config attribute with one named `PreserveInitializers`. It also changes the default behavior, thus breaking, again.

#### The solution

As this is a recently introduced feature and EmptyConstructor.Fody has a long history I assume it's not covering a very common use case. Therefore I'd say it's entirely fine to be opt-in instead of opt-out.
Given the current implementation is [buggy, in a breaking way](https://github.com/Fody/EmptyConstructor/issues/143) makes it very sensible to be opt-in instead of opt-out.
Furthermore, I suppose the author of the feature, @NorekZ, does not (currently) require the bug to be fixed, thus there is no immediate pressure to fix it and it may well take quite some time to have it fixed. This speaks for making it opt-in, at least until it's stable.
A perfect implementation of the feature could be quite complicated, anyway.
Furthermore I deem it an advanced feature because it's a bit difficult to understand what exactly it does. This speaks for making it opt-in forever (or until we know better).

To sum it up: make it opt-in and leave it like that.

---------
I've also considered making this a less-breaking change by only changing the default value of `DoNotPreserveInitializers`, but not the name.
Here's my reasoning not to:
All existing users only (had to) introduced the flag in case it wasn't the intended behavior. All of them now have to ensure that all their FodyWeavers.xml have the correct config. The reduced burden of maintaining this (when adding new projects etc.) should outweigh the negative effect of having to remove the attribute.
All users who haven't updated yet might be better off by changing the default behavior and won't be affected by the name change.
Thus, only the users who prefer the feature to be on remain as "victims". Those won't be many, as the feature has only been introduced very recently.

@SimonCropp do you think that's a fair evaluation?

#### Todos

 * [x] Related issues: Alleviates, but doesn't fix #143
 * [x] Tests
 * [x] Documentation