### PR TITLE
PreserveInitializes feature now correctly handles record constructors

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyToReference\AssemblyToReference.csproj" />

--- a/AssemblyToProcess/RecordWithParameter.cs
+++ b/AssemblyToProcess/RecordWithParameter.cs
@@ -1,0 +1,3 @@
+﻿#if NET5_0
+public record RecordWithParameter(string Parameter);
+#endif

--- a/AssemblyToProcess/RecordWithParameterAndInitializedField.cs
+++ b/AssemblyToProcess/RecordWithParameterAndInitializedField.cs
@@ -1,0 +1,6 @@
+﻿#if NET5_0
+public record RecordWithParameterAndInitializedField(string Parameter)
+{
+    public int X = 9;
+}
+#endif

--- a/EmptyConstructor.sln.DotSettings
+++ b/EmptyConstructor.sln.DotSettings
@@ -591,6 +591,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EdotCover_002EIde_002ECore_002EFilterManagement_002EModel_002ESolutionFilterSettingsManagerMigrateSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/Tests/IntegrationTests.cs
+++ b/Tests/IntegrationTests.cs
@@ -184,4 +184,12 @@ public class IntegrationTests
         var instance = testResult.GetInstance("Bug143Child");
         Assert.NotNull(instance);
     }
+
+#if NET5_0
+    [Fact]
+    public void RecordWithParameter()
+    {
+        testResult.GetInstance("RecordWithParameter");
+    }
+#endif
 }

--- a/Tests/PreserveInitializersIntegrationTests.cs
+++ b/Tests/PreserveInitializersIntegrationTests.cs
@@ -39,4 +39,19 @@ public class PreserveInitializersIntegrationTests
         var instance = testResult.GetInstance("Bug143Child");
         Assert.NotNull(instance);
     }
+
+#if NET5_0
+    [Fact]
+    public void RecordWithParameter()
+    {
+        testResult.GetInstance("RecordWithParameter");
+    }
+
+    [Fact]
+    public void RecordWithParameterAndInitializedField()
+    {
+        var instance = testResult.GetInstance("RecordWithParameterAndInitializedField");
+        Assert.Equal(9, instance.X);
+    }
+#endif
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.2;net5.0</TargetFrameworks>
     <DisableFody>true</DisableFody>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Solves issue of PreserveInitializers feature that generated invalid IL code for C# 9 records.

I also added tests to cover this use case.

I needed to add "net5.0" target for _AssemblyToProcess_ assembly to be able to use "record" keyword and also for _Tests_ assembly.

Should not break anything else - tests are passing.